### PR TITLE
Implement Logo without "LibCrypt" text

### DIFF
--- a/src/panes/info_pane.py
+++ b/src/panes/info_pane.py
@@ -2,7 +2,6 @@ from typing import override
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
-from textual.geometry import Offset
 from textual.widget import Widget
 from textual.widgets import Label, Static
 from pyfiglet import Figlet, FigletString


### PR DESCRIPTION
This PR was made based on @Mharis13 pull request.

The logo is cool but it feels redundant with the title of the APP. That's why I have added a logo without much text.
It is supposed to be a magic orb that says `.py` and `.sh` meaning that Libcrypt recognized those scripts.

I am not an ASCII expert but ChatGPT helped me with that. Also I have tried to add animations but it felt weird or annoying and I preferred a static design.

<img width="2807" height="1450" alt="image" src="https://github.com/user-attachments/assets/4ec9484c-adc4-4493-9627-2773382fb9ef" />
